### PR TITLE
Fix S16 volume scaling in the write callback

### DIFF
--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -1136,7 +1136,10 @@ impl PulseStream<'_> {
                             {
                                 let b = buffer as *mut i16;
                                 for i in 0..samples {
-                                    unsafe { *b.offset(i) *= self.volume as i16 };
+                                    unsafe {
+                                        *b.offset(i) =
+                                            (f32::from(*b.offset(i)) * self.volume) as i16
+                                    };
                                 }
                             } else {
                                 let b = buffer as *mut f32;

--- a/src/backend/stream.rs
+++ b/src/backend/stream.rs
@@ -1120,6 +1120,10 @@ impl PulseStream<'_> {
                             }
                             return;
                         }
+                        assert!(
+                            got as usize <= size / frame_size,
+                            "data callback returned more frames than requested"
+                        );
 
                         // If more iterations move offset of read buffer
                         if !input_data.is_null() {
@@ -1128,8 +1132,7 @@ impl PulseStream<'_> {
                         }
 
                         if self.volume != PULSE_NO_GAIN {
-                            let samples = (self.output_sample_spec.channels as usize * size
-                                / frame_size) as isize;
+                            let samples = got as isize * self.output_sample_spec.channels as isize;
 
                             if self.output_sample_spec.format == PA_SAMPLE_S16BE
                                 || self.output_sample_spec.format == PA_SAMPLE_S16LE


### PR DESCRIPTION
Two fixes to the client-side gain applied in `trigger_user_callback`.

**`set_volume` silences S16 streams instead of attenuating them.** The gain was applied as `*b.offset(i) *= self.volume as i16`, which truncates the *gain factor* to an integer before the multiply: any volume in `[0.01, 0.99]` becomes `0`, so the stream is muted outright. Only `1.0` (and `0.0`) behaved correctly. This is a mistranslation of the C backend, where `b[i] *= stm->volume` promotes the sample to float and converts back; it's been there since the original port in 2017, unnoticed because Gecko negotiates float32. The sample is now widened to `f32`, scaled, and converted back — `f32 as i16` saturates, so this also removes a latent overflow for out-of-contract gains above 1.0.

**The gain loop covered more frames than the callback filled.** `samples` was derived from the whole block returned by `begin_write`, but only `got * frame_size` bytes are handed to `pa_stream_write`, so the tail was wasted work over uninitialized buffer memory. It now scales `got` frames. Drain padding is unaffected: the padding block zeroes and extends `got` after this loop, so those frames were always meant to be silent. An `assert!` on the callback's return value pins down the in-bounds invariant that both this loop and the `write()` call already relied on.
